### PR TITLE
goreleaser: don't build for arm64

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -16,7 +16,6 @@ builds:
     - darwin
   goarch:
     - amd64
-    - arm64
 archives:
 - id: bin
   format: binary


### PR DESCRIPTION
Seems like the `notify` library requires `CGO_ENABLED=1` to be set: https://github.com/rjeczalik/notify/issues/204

But goreleaser requires a bit more effort to get that working: https://goreleaser.com/cookbooks/cgo-and-crosscompiling/

So for now, let's disable this so we can get a first release out.